### PR TITLE
refactor: convert module from class to function

### DIFF
--- a/lib/interfaces.ts
+++ b/lib/interfaces.ts
@@ -2,7 +2,7 @@ import { ComputedRef, DeepReadonly, Ref, UnwrapNestedRefs, WatchCallback } from 
 
 export interface IModule<S extends IState, G extends IGetters, M extends IMutations> {
   readonly options: IModuleOptions<S, G, M>
-  flatten(): IFlattenedModule<S, G, M>
+  plugins?: IPlugin<S>[]
 }
 
 /* eslint-disable @typescript-eslint/no-explicit-any */

--- a/lib/module.ts
+++ b/lib/module.ts
@@ -3,84 +3,46 @@ import {
   IFlattenedModule,
   IGetters,
   IModule,
-  IModuleMetadata,
   IModuleOptions,
   IMutations,
-  IPlugin,
   IState,
 } from './interfaces'
 
 export function useModule<S extends IState, G extends IGetters, M extends IMutations>(
   options: IModuleOptions<S, G, M>,
 ): IFlattenedModule<S, G, M> {
-  const module = new Module<S, G, M>(options)
-  return module.flatten()
+  const module = createModule<S, G, M>(options)
+  return flatten(module)
 }
 
-export class Module<S extends IState, G extends IGetters, M extends IMutations>
-  implements IModule<S, G, M>
-{
-  plugins?: IPlugin<S>[]
-
-  constructor(public readonly options: IModuleOptions<S, G, M>) {
-    this.plugins = options.plugins?.map((pluginInit) => {
-      if (typeof pluginInit === 'function') {
-        return pluginInit(this)
-      }
-      return pluginInit
-    })
+export function createModule<S extends IState, G extends IGetters, M extends IMutations>(
+  options: IModuleOptions<S, G, M>,
+): IModule<S, G, M> {
+  const module: IModule<S, G, M> = {
+    options,
   }
-
-  flatten(): IFlattenedModule<S, G, M> {
-    const flattenedModule = {} as IFlattenedModule<S, G, M>
-
-    // metadata
-    flattenedModule.__metadata = this.getMetadata()
-
-    // state
-    const initialState = this.getInitialState()
-    const state = reactive(initialState ?? ({} as S))
-
-    // map state properties to Ref<T>
-    for (const key in state) {
-      flattenedModule[key] = readonly(toRef(state, key)) as IFlattenedModule<
-        S,
-        G,
-        M
-      >[Extract<keyof UnwrapNestedRefs<S>, string>]
+  module.plugins = options.plugins?.map((pluginInit) => {
+    if (typeof pluginInit === 'function') {
+      return pluginInit(module)
     }
+    return pluginInit
+  })
+  return module
+}
 
-    // getters
-    const getters = this.options.getters?.(state) ?? ({} as G)
-    for (const key in getters) {
-      flattenedModule[key] = computed(getters[key]) as IFlattenedModule<S, G, M>[Extract<
-        keyof G,
-        string
-      >]
-    }
+export function flatten<S extends IState, G extends IGetters, M extends IMutations>(
+  module: IModule<S, G, M>,
+): IFlattenedModule<S, G, M> {
+  const flattenedModule = {} as IFlattenedModule<S, G, M>
+  const { options, plugins } = module
 
-    // mutations
-    const mutations = this.options.mutations?.(state) ?? ({} as M)
-    for (const key in mutations) {
-      flattenedModule[key] = mutations[key] as IFlattenedModule<S, G, M>[Extract<
-        keyof M,
-        string
-      >]
-    }
-
-    // plugins
-    this.registerOnDataChangeHooks(state)
-
-    return flattenedModule
-  }
-
-  private getInitialState(): S {
-    const { stateInit } = this.options
+  const getInitialState = (): S => {
+    const { stateInit } = options
     const source = stateInit?.() ?? ({} as S)
-    if (!this.plugins?.length) {
+    if (!plugins?.length) {
       return source
     }
-    return this.plugins.reduce((state, plugin) => {
+    return plugins.reduce((state, plugin) => {
       if (plugin.onStateInit) {
         return plugin.onStateInit(state)
       }
@@ -88,8 +50,8 @@ export class Module<S extends IState, G extends IGetters, M extends IMutations>
     }, source)
   }
 
-  private registerOnDataChangeHooks(state: UnwrapNestedRefs<S>): void {
-    const onDataChangeHooks = this.plugins
+  const registerOnDataChangeHooks = (state: UnwrapNestedRefs<S>): void => {
+    const onDataChangeHooks = plugins
       ?.filter((plugin) => plugin.onDataChange !== undefined)
       .map((plugin) => plugin.onDataChange)
     if (onDataChangeHooks?.length) {
@@ -102,11 +64,45 @@ export class Module<S extends IState, G extends IGetters, M extends IMutations>
     }
   }
 
-  private getMetadata(): IModuleMetadata {
-    const { name, version } = this.options
-    return {
-      name,
-      version,
-    }
+  // metadata
+  flattenedModule.__metadata = {
+    name: options.name,
+    version: options.version,
   }
+
+  // state
+  const initialState = getInitialState()
+  const state = reactive(initialState ?? ({} as S))
+
+  // map state properties to Ref<T>
+  for (const key in state) {
+    flattenedModule[key] = readonly(toRef(state, key)) as IFlattenedModule<
+      S,
+      G,
+      M
+    >[Extract<keyof UnwrapNestedRefs<S>, string>]
+  }
+
+  // getters
+  const getters = options.getters?.(state) ?? ({} as G)
+  for (const key in getters) {
+    flattenedModule[key] = computed(getters[key]) as IFlattenedModule<S, G, M>[Extract<
+      keyof G,
+      string
+    >]
+  }
+
+  // mutations
+  const mutations = options.mutations?.(state) ?? ({} as M)
+  for (const key in mutations) {
+    flattenedModule[key] = mutations[key] as IFlattenedModule<S, G, M>[Extract<
+      keyof M,
+      string
+    >]
+  }
+
+  // plugins
+  registerOnDataChangeHooks(state)
+
+  return flattenedModule
 }


### PR DESCRIPTION
@abemscac I converted the Module class implementation to a function. The other option is to introduce a bundler (rollup, etc) that can convert classes to an older style of javascript, but I didn't want to introduce a bunch of dependencies just for that purpose.

It's annoying to have to base our code on what works with Cypress (webpack 4), but I think this is the simplest solution.